### PR TITLE
[ new ] instantiate command

### DIFF
--- a/src/Velo/Commands.idr
+++ b/src/Velo/Commands.idr
@@ -8,6 +8,7 @@ import Data.Maybe
 import public Toolkit.Commands
 
 import Velo.Core
+import Velo.IR.AST
 
 %default total
 
@@ -18,6 +19,7 @@ data Cmd = Quit
          | TypeOfHole String
          | Eval
          | CSE
+         | Instantiate String String
          | Show
          | ConstantFolding
          | Load String
@@ -43,6 +45,11 @@ commands
                  (options [REQ "name"])
                  TypeOfHole
                  "Show the specified hole."
+
+    , newCommand (names ["instantiate", "i"])
+                 (options [REQ "name", REQ "term"])
+                 Instantiate
+                 "Instantiate the specified hole with the given term."
 
     , newCommand (names ["eval"])
                  Eval

--- a/src/Velo/Commands.idr
+++ b/src/Velo/Commands.idr
@@ -47,7 +47,7 @@ commands
                  "Show the specified hole."
 
     , newCommand (names ["instantiate", "i"])
-                 (options [REQ "name", REQ "term"])
+                 (options [REQ "name", REST "term"])
                  Instantiate
                  "Instantiate the specified hole with the given term."
 
@@ -74,9 +74,16 @@ commands
     ]
 
 export
-Show OptDesc where
+Show (OptDesc b) where
   show (REQ str) = "[\{str}]"
   show (OPT str str1) = "<\{str1}> [DEFAULT \{str}]"
+  show (REST str) = "{\{str}}"
+
+export
+Show (OptDescs b) where
+  show [] = ""
+  show [o] = show o
+  show (o :: os) = "\{show o} \{show os}"
 
 export
 Show Commands.Error where
@@ -94,14 +101,13 @@ Show Commands.Error where
 show : CommandDesc a -> String
 show cmd
     = trim $ unlines [unwords ["[\{concat $ intersperse "," (map (":" <+>) $ forget $ name cmd)}]"
-                              , maybe "" (unwords . map show . forget) (argsDesc cmd)
+                              , show (argsDesc cmd)
                               ]
                      , "\t" <+> maybe "" id (help cmd)
                      ]
 
 export
 helpStr : String
-helpStr
-  = unlines (map show (forget commands))
+helpStr = unlines (map show $ forget commands) where
 
 -- [ EOF ]

--- a/src/Velo/Elaborator.idr
+++ b/src/Velo/Elaborator.idr
@@ -45,19 +45,41 @@ nonEmpty (x :: xs)
   = Yes IsNonEmpty
 
 public export
-record ElabResult where
-  constructor MkElabResult
+record SynthResult (ctxt : SnocList Ty) where
+  constructor MkSynthResult
   {ty : Ty}
   metas : List Meta
-  term : Term metas [<] ty
+  term : Term metas ctxt ty
 
-export
-elab : Raw
-    -> Velo ElabResult
-elab ast
-  = do (ty ** holes ** t) <- synth [<] ast
-       let (metas ** inv) = initInvariant [<] holes
-       let t = wscoped t inv
-       pure (MkElabResult metas t)
+namespace Synth
+
+  export
+  elab : All Item ctxt
+      -> Raw
+      -> Velo (SynthResult ctxt)
+  elab gam ast
+    = do (ty ** holes ** t) <- synth gam ast
+         let (metas ** inv) = initInvariant gam holes
+         let t = wscoped t inv
+         pure (MkSynthResult metas t)
+
+public export
+record CheckResult (ctxt : SnocList Ty) (ty : Ty) where
+  constructor MkCheckResult
+  metas : List Meta
+  term : Term metas ctxt ty
+
+namespace Check
+
+  export
+  elab : All Item ctxt
+      -> (ty : Ty)
+      -> Raw
+      -> Velo (CheckResult ctxt ty)
+  elab gam ty ast
+    = do (holes ** t) <- check gam ty ast
+         let (metas ** inv) = initInvariant gam holes
+         let t = wscoped t inv
+         pure (MkCheckResult metas t)
 
 -- [ EOF ]

--- a/src/Velo/Elaborator/Instantiate.idr
+++ b/src/Velo/Elaborator/Instantiate.idr
@@ -1,0 +1,88 @@
+module Velo.Elaborator.Instantiate
+
+import Data.SnocList.Quantifiers
+import Data.List.Quantifiers
+import Toolkit.Data.List.Member
+
+import Velo.Types
+import Velo.IR.Common
+import Velo.IR.Term
+
+%default total
+
+export
+embed : Term [] ctxt ty -> Term metas ctxt ty
+-- Cannot be bothered to implement a complicated identity function
+embed = believe_me
+
+substV :
+  IsVar old ty ->
+  Subst metas new old ->
+  Term metas new ty
+substV v [<] = absurd v
+substV v@_ (sg :< t) with (view v)
+  _ | Here = t
+  _ | There v' = substV v' sg
+
+export
+subst :
+  Term metas old ty ->
+  Subst metas new old ->
+  Term metas new ty
+
+substS :
+  Subst metas old ty ->
+  Subst metas new old ->
+  Subst metas new ty
+
+substs :
+  {0 tys : List Ty} ->
+  All (Term metas old) tys ->
+  Subst metas new old ->
+  All (Term metas new) tys
+
+subst (Var v) sg = substV v sg
+subst (Met m sg') sg = Met m (substS sg' sg)
+subst (Fun b) sg = Fun (subst b (mapProperty (rename shift) sg :< Var here))
+subst (Call op ts) sg = Call op (substs ts sg)
+
+substS [<] sg = [<]
+substS (args :< arg) sg = substS args sg :< subst arg sg
+
+substs [] sg = []
+substs (t :: ts) sg = subst t sg :: substs ts sg
+
+export
+instantiate :
+  Term metas ctxt ty ->
+  (p : IsMember metas m) ->
+  Term (drop p) m.metaScope m.metaType ->
+  Term (drop p) ctxt ty
+
+instantiates :
+  {0 tys : List Ty} ->
+  All (Term metas ctxt) tys ->
+  (p : IsMember metas m) ->
+  Term (drop p) m.metaScope m.metaType ->
+  All (Term (drop p) ctxt) tys
+
+instantiateS :
+  Subst metas ctxt tys ->
+  (p : IsMember metas m) ->
+  Term (drop p) m.metaScope m.metaType ->
+  Subst (drop p) ctxt tys
+
+instantiate (Var v) p t = Var v
+instantiate (Met mem sg) prf t with (hetDecEq prf mem)
+  instantiate (Met mem sg) .(mem) t
+    | Yes (Refl, Refl) = subst t (instantiateS sg mem t)
+  instantiate (Met mem sg) prf t
+    | No neq = Met (dropNeq neq) (instantiateS sg prf t)
+instantiate (Fun b) p t = Fun (instantiate b p t)
+instantiate (Call op ts) p t = Call op (instantiates ts p t)
+
+instantiates [] p t = []
+instantiates (arg :: args) p t = instantiate arg p t :: instantiates args p t
+
+instantiateS [<] p t = [<]
+instantiateS (args :< arg) p t = instantiateS args p t :< instantiate arg p t

--- a/src/Velo/Error/Pretty.idr
+++ b/src/Velo/Error/Pretty.idr
@@ -35,7 +35,7 @@ Show (Evaluating.Error) where
 
 Show (Elaborating.Error) where
   show (Hole msg)
-    = "Hole eror:\n\t\{show msg}"
+    = "Hole error:\n\t\{show msg}"
   show (Err fc err)
     = unlines [show fc
               , show err]

--- a/src/Velo/IR/Common.idr
+++ b/src/Velo/IR/Common.idr
@@ -10,6 +10,7 @@ import public Toolkit.Item
 import Data.SnocList.Quantifiers
 
 import Toolkit.Data.Comparison.Informative
+import Toolkit.Data.List.Member
 
 %default total
 
@@ -167,11 +168,12 @@ extract (x :: xs) (There ltr)
 export
 getByName : (n  : String)
          -> (ms : List Meta)
-         -> Maybe Meta
-getByName n ms
-  = case get n ms of
-      No _ => Nothing
-      Yes prf => Just (extract ms prf)
+         -> Maybe (m : Meta ** IsMember ms m)
+getByName n [] = Nothing
+getByName n (MkMeta nm scp ty :: ms)
+  = ifThenElse (n == nm) (Just (_ ** here)) $ do
+    (m ** prf) <- getByName n ms
+    pure (m ** shift prf)
 
 export
 Show (Prim tys ty) where

--- a/src/Velo/Parser.idr
+++ b/src/Velo/Parser.idr
@@ -49,6 +49,7 @@ mutual
   hole
     = do s <- Toolkit.location
          symbol "?"
+         commit
          h <- name
          e <- Toolkit.location
          pure (Hole (newFC s e) h)
@@ -58,6 +59,7 @@ mutual
       <|> do s <- Toolkit.location
              symbol "("
              keyword "inc"
+             commit
              i <- expr
              symbol ")"
              e <- Toolkit.location
@@ -68,6 +70,7 @@ mutual
     = do s <- Toolkit.location
          symbol "("
          keyword "add"
+         commit
          l <- expr
          r <- expr
          symbol ")"
@@ -79,6 +82,7 @@ mutual
     = do s <- Toolkit.location
          symbol "("
          keyword "and"
+         commit
          l <- expr
          r <- expr
          symbol ")"
@@ -90,6 +94,7 @@ mutual
     do s <- Toolkit.location
        symbol "("
        keyword "fun"
+       commit
        n <- name
        symbol ":"
        ty <- type
@@ -108,6 +113,7 @@ mutual
              symbol "="
              v <- expr
              keyword "in"
+             commit
              b <- expr
              e <- Toolkit.location
              pure (Let (newFC s e) n v b)
@@ -135,6 +141,7 @@ mutual
        symbol "("
        a <- expr
        symbol ":"
+       commit
        ty <- type
        symbol ")"
        e <- Toolkit.location

--- a/src/Velo/Pipeline.idr
+++ b/src/Velo/Pipeline.idr
@@ -39,7 +39,7 @@ pipeline opts
        ast <- fromFile fname
        putStrLn "# Finished Parsing"
 
-       res <- elab ast
+       res <- elab [<] ast
 
        putStrLn "# Finished Type Checking"
 

--- a/tests/working/004-repl/expected
+++ b/tests/working/004-repl/expected
@@ -8,6 +8,8 @@ Velo> [:q,:quit,:exit]
 	Show the current list of holes.
 [:hole_type,:t] [name]
 	Show the specified hole.
+[:instantiate,:i] [name] [term]
+	Instantiate the specified hole with the given term.
 [:eval] 
 	Eval the loaded program.
 [:cse] 

--- a/tests/working/004-repl/expected
+++ b/tests/working/004-repl/expected
@@ -8,7 +8,7 @@ Velo> [:q,:quit,:exit]
 	Show the current list of holes.
 [:hole_type,:t] [name]
 	Show the specified hole.
-[:instantiate,:i] [name] [term]
+[:instantiate,:i] [name] {term}
 	Instantiate the specified hole with the given term.
 [:eval] 
 	Eval the loaded program.

--- a/tests/working/006-instantiate/expected
+++ b/tests/working/006-instantiate/expected
@@ -2,7 +2,8 @@ Running Test
 Velo> # Finished Parsing
 # Finished Type-Checking
 Velo> (fun m : Nat
-=> (add ?hole1 let n = (inc zero) in (add let x = m in ?hole1 ?hole2)))
+=> (add ?hole1 let n = (inc zero)
+   in (add let x = m in ?hole1 (add ?hole2 ?hole3))))
 Velo> x : Nat
 ----------
 ?hole1 : Nat
@@ -12,6 +13,28 @@ b : Nat
 ----------
 ?hole2 : Nat
 
-Velo> (fun m : Nat => (add m let n = (inc zero) in (add m ?hole2)))
-Velo> Not a recognised command.
+x : Nat
+b : Nat
+----------
+?hole3 : Nat
+
+Velo> (fun m : Nat => (add m let n = (inc zero) in (add m (add ?hole2 ?hole3))))
+Velo> x : Nat
+b : Nat
+----------
+?hole2 : Nat
+
+x : Nat
+b : Nat
+----------
+?hole3 : Nat
+
+Velo> (fun m : Nat => (add m let n = (inc zero) in (add m (add (add m n) ?hole3))))
+Velo> x : Nat
+b : Nat
+----------
+?hole3 : Nat
+
+Velo> (fun m : Nat => (add m let n = (inc zero) in (add m (add (add m n) zero))))
+Velo> No Holes
 Velo> Quitting, Goodbye.

--- a/tests/working/006-instantiate/expected
+++ b/tests/working/006-instantiate/expected
@@ -1,0 +1,17 @@
+Running Test
+Velo> # Finished Parsing
+# Finished Type-Checking
+Velo> (fun m : Nat
+=> (add ?hole1 let n = (inc zero) in (add let x = m in ?hole1 ?hole2)))
+Velo> x : Nat
+----------
+?hole1 : Nat
+
+x : Nat
+b : Nat
+----------
+?hole2 : Nat
+
+Velo> (fun m : Nat => (add m let n = (inc zero) in (add m ?hole2)))
+Velo> Not a recognised command.
+Velo> Quitting, Goodbye.

--- a/tests/working/006-instantiate/input
+++ b/tests/working/006-instantiate/input
@@ -2,5 +2,9 @@
 :show
 :holes
 :instantiate hole1 x
+:holes
 :instantiate hole2 (add x b)
+:holes
+:i hole3 (zero : nat)
+:holes
 :quit

--- a/tests/working/006-instantiate/input
+++ b/tests/working/006-instantiate/input
@@ -1,0 +1,6 @@
+:load main.velo
+:show
+:holes
+:instantiate hole1 x
+:instantiate hole2 (add x b)
+:quit

--- a/tests/working/006-instantiate/main.velo
+++ b/tests/working/006-instantiate/main.velo
@@ -1,4 +1,4 @@
 (fun x : nat =>
   (add ?hole1
        let b = (inc zero)
-       in (add ?hole1 ?hole2)))
+       in (add ?hole1 (add ?hole2 ?hole3))))

--- a/tests/working/006-instantiate/main.velo
+++ b/tests/working/006-instantiate/main.velo
@@ -1,0 +1,4 @@
+(fun x : nat =>
+  (add ?hole1
+       let b = (inc zero)
+       in (add ?hole1 ?hole2)))

--- a/tests/working/006-instantiate/run
+++ b/tests/working/006-instantiate/run
@@ -1,0 +1,10 @@
+echo "Running Test"
+
+$1 --repl < input
+
+
+# Local Variables:
+# mode: sh
+# End:
+
+# -- [ EOF ]

--- a/velo.ipkg
+++ b/velo.ipkg
@@ -28,6 +28,7 @@ modules = Velo.Types
         , Velo.Elaborator.Holey
         , Velo.Elaborator.Term
         , Velo.Elaborator.CoDeBruijn
+        , Velo.Elaborator.Instantiate
 
         , Velo.Lexer.Token
         , Velo.Lexer


### PR DESCRIPTION
@jfdm I don't think the command parsing framework can handle this setting?

Cf. the attempt
```
:instantiate hole2 (add x b)
```
and the corresponding error
```
Velo> Not a recognised command.
```