### PR TITLE
[ new ] mention of language fragments work.

### DIFF
--- a/paper/2023-EVCS/content/conclusion.tex
+++ b/paper/2023-EVCS/content/conclusion.tex
@@ -9,9 +9,7 @@ The weakest supported core criteria, unfortunately, is that for \emph{editor} su
 %
 Languages created through \Idris{} do not get an editor, they are free form languages which require their parsers and elaborators be hand written.
 This can change with future investigation.
-\Idris{} has support for elaborator reflection
-% ~\cite{DBLP:conf/icfp/ChristiansenB16} -- removed due to restrictions on bibliography.
-which provides a vehicle through which deriving parsers and elaborators can happen.
+\Idris{} has support for elaborator reflection~\cite{DBLP:conf/icfp/ChristiansenB16} which provides a vehicle through which deriving parsers and elaborators can happen.
 
 
 There are, however, more criteria from the language workbench feature model to consider:
@@ -54,7 +52,9 @@ This is a hard problem:
 %
 One has to not only combine their semantics but also the remainder of the workbench tooling.
 %
-The \emph{Effects} library~\cite{DBLP:conf/icfp/Brady13} provides clues as to how we can compose \acp{dsl} horizontally but not vertically.
+The \emph{language fragments} approach~\cite{10.1145/3563355} does provide a solution for intrinsically typed definitional interpreters, but not workbench tooling.
+How the language fragments approach can extended to our approach based on inductive families, and workbench tooling, is an open area of investigation.
+%The \emph{Effects} library~\cite{DBLP:conf/icfp/Brady13} provides clues as to how we can compose \acp{dsl} horizontally but not vertically .
 
 
 We strongly believe that with future engineering we can satisfy these missing criteria,

--- a/paper/2023-EVCS/content/conclusion.tex
+++ b/paper/2023-EVCS/content/conclusion.tex
@@ -52,8 +52,8 @@ This is a hard problem:
 %
 One has to not only combine their semantics but also the remainder of the workbench tooling.
 %
-The \emph{language fragments} approach~\cite{10.1145/3563355} does provide a solution for intrinsically typed definitional interpreters, but not workbench tooling.
-How the language fragments approach can extended to our approach based on inductive families, and workbench tooling, is an open area of investigation.
+The \emph{language fragments} approach~\cite{10.1145/3563355} does provide a solution to language composability for intrinsically typed definitional interpreters, but this does not extend to workbench tooling.
+How the language fragments approach applied to our approach to realising semantics (based on inductive families) and also to creating composable workbench tooling is an open area of investigation.
 %The \emph{Effects} library~\cite{DBLP:conf/icfp/Brady13} provides clues as to how we can compose \acp{dsl} horizontally but not vertically .
 
 

--- a/paper/2023-EVCS/content/introduction.tex
+++ b/paper/2023-EVCS/content/introduction.tex
@@ -44,7 +44,7 @@ demonstrated that this is not an inescapable fate~\cite{DBLP:conf/ecoop/Brady21}
 But can we now claim that dependently typed languages qualify as
 language workbenches?
 
-\Velo{}\footnote{\url{https://github.com/jfdm/velo-lang}} is a minimal functional language that we have realised in \Idris{}
+\Velo{}\footnote{\url{https://github.com/jfdm/velo-lang}}\footnote{For the final version we will replace this link to a DOI-backed artifact.} is a minimal functional language that we have realised in \Idris{}
 to showcase dependently typed techniques to implement and manipulate \acp{ir}.
 %
 This paper introduces \Velo{} but, most of all, seeks to show that

--- a/paper/2023-EVCS/paper.bib
+++ b/paper/2023-EVCS/paper.bib
@@ -1,3 +1,46 @@
+@article{10.1145/3563355,
+  author =       {van der Rest, Cas and Poulsen, Casper Bach and
+                  Rouvoet, Arjen and Visser, Eelco and Mosses, Peter},
+  title =        {Intrinsically-Typed Definitional Interpreters \`{a}
+                  La Carte},
+  year =         {2022},
+  issue_date =   {October 2022},
+  publisher =    {Association for Computing Machinery},
+  address =      {New York, NY, USA},
+  volume =       {6},
+  number =       {OOPSLA2},
+  url =          {https://doi.org/10.1145/3563355},
+  doi =          {10.1145/3563355},
+  abstract =     {Specifying and mechanically verifying type safe
+                  programming languages requires significant
+                  effort. This effort can in theory be reduced by
+                  defining and reusing pre-verified, modular
+                  components. In practice, however, existing
+                  approaches to modular mechanical verification
+                  require many times as much specification code as
+                  plain, monolithic definitions. This makes it hard to
+                  develop new reusable components, and makes existing
+                  component specifications hard to grasp. We present
+                  an alternative approach based on intrinsically-typed
+                  interpreters, which reduces the size and complexity
+                  of modular specifications as compared to existing
+                  approaches. Furthermore, we introduce a new
+                  abstraction for safe-by-construction specification
+                  and composition of pre-verified type safe language
+                  components: language fragments. Language fragments
+                  are about as concise and easy to develop as plain,
+                  monolithic intrinsically-typed interpreters, but
+                  require about 10 times less code than previous
+                  approaches to modular mechanical verification of
+                  type safety.},
+  journal =      {Proc. ACM Program. Lang.},
+  month =        {oct},
+  articleno =    {192},
+  numpages =     {30},
+  keywords =     {Dependently Typed Programming, Modularity, Reuse,
+                  Definitional Interpreters, Type Safety}
+}
+
 @inproceedings{DBLP:conf/icfp/ClaessenH00,
   author    = {Koen Claessen and
                John Hughes},
@@ -467,16 +510,17 @@ keywords = {type soundness, DOT, Scala, dependent object types, Definitional int
 }
 
 @article{MANUAL:journals/math/debruijn72,
-author = {de Bruijn, Nicolaas Govert},
-title = {Lambda calculus notation with nameless dummies, a tool for automatic formula manipulation, with application to the {C}hurch-{R}osser theorem},
-journal = {Indagationes Mathematicae (Proceedings)},
-volume = {75},
-number = {5},
-pages = {381-392},
-year = {1972},
-issn = {1385-7258},
-doi = {https://doi.org/10.1016/1385-7258(72)90034-0},
-url = {https://www.sciencedirect.com/science/article/pii/1385725872900340},
+  author =       {de Bruijn, Nicolaas Govert},
+  title =        {Lambda calculus notation with nameless dummies, a
+                  tool for automatic formula manipulation, with
+                  application to the {C}hurch-{R}osser theorem},
+  journal =      {Indagationes Mathematicae (Proceedings)},
+  volume =       75,
+  number =       5,
+  pages =        {381-392},
+  year =         1972,
+  issn =         {1385-7258},
+  doi =          {10.1016/1385-7258(72)90034-0},
 }
 
 @article{DBLP:journals/fac/Dybjer94,


### PR DESCRIPTION
The work from Cas van der Rest et al (Eelco Visser's group) was accepted and published at OOPSLA *after* we submitted the paper. It is an important piece to mention when discussing language composibility. I have replaced the effects reference with this one.